### PR TITLE
Fix get_gpu_info()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,4 @@ cython_debug/
 
 # Wandb offline
 */wandb/*
+test_snapshot.json

--- a/ttex/log/utils/system_snapshot.py
+++ b/ttex/log/utils/system_snapshot.py
@@ -68,7 +68,13 @@ def get_gpu_info():
     elif shutil.which("rocm-smi"):
         return {"gpu": run_cmd("rocm-smi", parse="lines")}
     elif shutil.which("lspci"):
-        return {"gpu": run_cmd("lspci", parse="lines", filter=lambda line: any(s in line.lower() for s in ("vga", "3d", "2d")))}
+        return {
+            "gpu": run_cmd(
+                "lspci",
+                parse="lines",
+                filter=lambda line: any(s in line.lower() for s in ("vga", "3d", "2d")),
+            )
+        }
     else:
         return {"gpu": "No GPU information available"}
 

--- a/ttex/log/utils/system_snapshot.py
+++ b/ttex/log/utils/system_snapshot.py
@@ -63,10 +63,10 @@ def get_memory_info():
 
 
 def get_gpu_info():
-    if shutil.which("lspci"):
-        return {"gpu": run_cmd("lspci", parse="lines", filter=lambda line: any(s in line.lower() for s in ("vga", "3d", "2d")))}
-    elif shutil.which("nvidia-smi"):
+    if shutil.which("nvidia-smi"):
         return {"gpu": run_cmd("nvidia-smi", parse="lines")}
+    elif shutil.which("lspci"):
+        return {"gpu": run_cmd("lspci", parse="lines", filter=lambda line: any(s in line.lower() for s in ("vga", "3d", "2d")))}
     else:
         return {"gpu": "No GPU information available"}
 

--- a/ttex/log/utils/system_snapshot.py
+++ b/ttex/log/utils/system_snapshot.py
@@ -65,6 +65,8 @@ def get_memory_info():
 def get_gpu_info():
     if shutil.which("nvidia-smi"):
         return {"gpu": run_cmd("nvidia-smi", parse="lines")}
+    elif shutil.which("rocm-smi"):
+        return {"gpu": run_cmd("rocm-smi", parse="lines")}
     elif shutil.which("lspci"):
         return {"gpu": run_cmd("lspci", parse="lines", filter=lambda line: any(s in line.lower() for s in ("vga", "3d", "2d")))}
     else:


### PR DESCRIPTION
get_gpu_info() failed on my system. This fixes the issues and changes the behavior by first checking for an Nvidia GPU, then an AMD GPU and only then resort the the generic lspci solution.